### PR TITLE
Use new transcriptions API

### DIFF
--- a/python/api_testing/api_test.py
+++ b/python/api_testing/api_test.py
@@ -1,5 +1,5 @@
-from idtap_api.client import SwaraClient
+from python.idtap_api.client import SwaraClient
 
 s = SwaraClient()
-s.get_all_pieces()
+s.get_viewable_transcriptions()
 

--- a/python/idtap_api/client.py
+++ b/python/idtap_api/client.py
@@ -105,21 +105,29 @@ class SwaraClient:
     def save_piece(self, piece: Dict[str, Any]) -> Any:
         return self._post_json("updateTranscription", piece)
 
+    def get_viewable_transcriptions(
+        self,
+        sort_key: str = "title",
+        sort_dir: str | int = 1,
+    ) -> Any:
+        params = {
+            "userId": self.user_id,
+            "sortKey": sort_key,
+            "sortDir": sort_dir,
+        }
+        # remove None values
+        params = {k: str(v) for k, v in params.items() if v is not None}
+        return self._get("api/transcriptions", params=params)
+
+    # backwards compatibility
     def get_all_pieces(
         self,
         sort_key: str = "title",
         sort_dir: str | int = 1,
         new_permissions: Optional[bool] = None,
     ) -> Any:
-        params = {
-            "userID": self.user_id,
-            "sortKey": sort_key,
-            "sortDir": sort_dir,
-            "newPermissions": new_permissions,
-        }
-        # remove None values
-        params = {k: str(v) for k, v in params.items() if v is not None}
-        return self._get("getAllTranscriptions", params=params)
+        """Deprecated alias for :meth:`get_viewable_transcriptions`."""
+        return self.get_viewable_transcriptions(sort_key=sort_key, sort_dir=sort_dir)
 
     def update_visibility(
         self,

--- a/python/idtap_api/tests/client_test.py
+++ b/python/idtap_api/tests/client_test.py
@@ -32,3 +32,11 @@ def test_save_piece():
     responses.post(endpoint, json={'ok': 1}, status=200)
     result = client.save_piece({'_id': '1'})
     assert result == {'ok': 1}
+
+@responses.activate
+def test_get_viewable_transcriptions():
+    client = SwaraClient()
+    endpoint = BASE + 'api/transcriptions'
+    responses.get(endpoint, json=[{'_id': '1'}], status=200)
+    result = client.get_viewable_transcriptions()
+    assert result == [{'_id': '1'}]


### PR DESCRIPTION
## Summary
- rename `get_all_pieces` to `get_viewable_transcriptions`
- call new `api/transcriptions` endpoint
- adjust api testing script and tests

## Testing
- `python -m pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6865cb46abf8832eb80b867fde7fa5cb