### PR TITLE
Fix: standardize UI for editing transcriptions permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
       "pbkdf2": "^3.1.3",
       "minimatch": "10.0.3",
       "form-data": "4.0.4",
-      "tmp": ">=0.2.4"
+      "tmp": ">=0.2.4",
+      "sha.js": ">=2.4.12"
     }
   },
   "main": "background.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   minimatch: 10.0.3
   form-data: 4.0.4
   tmp: '>=0.2.4'
+  sha.js: '>=2.4.12'
 
 importers:
 
@@ -3194,8 +3195,9 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  sha.js@2.4.11:
-    resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
     hasBin: true
 
   shallow-copy@0.0.1:
@@ -5325,7 +5327,7 @@ snapshots:
       cipher-base: 1.0.6
       inherits: 2.0.4
       ripemd160: 2.0.1
-      sha.js: 2.4.11
+      sha.js: 2.4.12
 
   create-hash@1.2.0:
     dependencies:
@@ -5333,7 +5335,7 @@ snapshots:
       inherits: 2.0.4
       md5.js: 1.3.5
       ripemd160: 2.0.2
-      sha.js: 2.4.11
+      sha.js: 2.4.12
 
   create-hmac@1.1.7:
     dependencies:
@@ -5342,7 +5344,7 @@ snapshots:
       inherits: 2.0.4
       ripemd160: 2.0.2
       safe-buffer: 5.2.1
-      sha.js: 2.4.11
+      sha.js: 2.4.12
 
   create-require@1.1.1: {}
 
@@ -6797,7 +6799,7 @@ snapshots:
       create-hmac: 1.1.7
       ripemd160: 2.0.1
       safe-buffer: 5.2.1
-      sha.js: 2.4.11
+      sha.js: 2.4.12
       to-buffer: 1.2.1
 
   perfect-debounce@1.0.0: {}
@@ -7054,10 +7056,11 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sha.js@2.4.11:
+  sha.js@2.4.12:
     dependencies:
       inherits: 2.0.4
       safe-buffer: 5.2.1
+      to-buffer: 1.2.1
 
   shallow-copy@0.0.1: {}
 

--- a/src/comps/PermissionsModal.vue
+++ b/src/comps/PermissionsModal.vue
@@ -13,49 +13,23 @@
           <div class='labelBox'>
             <label for ='editors'>Editors</label>
           </div>
-          <div class='userSelectColumn'>
-            <div class='usersBox'>
-              <div v-for='(editor, i) in selectedEditors' :key='i'>
-                <select v-model='selectedEditors[i]'>
-                  <option 
-                    v-for='(user, j) in allUsers' 
-                    :key='j'
-                    :value='user'
-                    >
-                    {{ `${user.name} , (${user.email})` }}
-                  </option>
-                </select>
-                <button @click='selectedEditors.splice(i, 1)'>-</button>
-              </div>
-            </div>
-            <div class='addButton'>
-              <button @click='addEditor'>+</button>
-            </div>
-          </div>
+          <UserSearch
+            :users='allUsers'
+            :includedUsers='selectedEditors'
+            @addUser='selectedEditors.push($event)'
+            @removeUser='selectedEditors = selectedEditors.filter(id => id !== $event)'
+          />
         </div>
         <div class='modalColumn wide' v-if='!visible'>
           <div class='labelBox'>
             <label for='viewers'>Viewers</label>
           </div>
-          <div class='userSelectColumn'>
-            <div class='usersBox'>
-              <div v-for='(viewer, i) in selectedViewers' :key='i'>
-                <select v-model='selectedViewers[i]'>
-                  <option 
-                    v-for='(user, j) in allUsers' 
-                    :key='j'
-                    :value='user'
-                    >
-                    {{ `${user.name} , (${user.email})` }}
-                  </option>
-                </select>
-                <button @click='selectedViewers.splice(i, 1)'>-</button>
-              </div>
-            </div>
-            <div>
-              <button @click='addViewer'>+</button>
-            </div>
-          </div>
+          <UserSearch
+            :users='allUsers'
+            :includedUsers='selectedViewers'
+            @addUser='selectedViewers.push($event)'
+            @removeUser='selectedViewers = selectedViewers.filter(id => id !== $event)'
+          />
         </div>
       </div>
       <div class='modalRow'>
@@ -72,25 +46,27 @@
 import { defineComponent, PropType } from 'vue';
 import { UserType } from '@shared/types';
 import { updateVisibility, getAllUsers } from '@/js/serverCalls';
+import UserSearch from '@/comps/files/UserSearch.vue';
 
 type PermissionsModalDataType = {
   visible: boolean,
   allUsers: UserType[],
-  selectedViewers: (UserType | undefined)[],
-  selectedEditors: (UserType | undefined)[],
-  userSelectHeight: number,
+  selectedViewers: string[],
+  selectedEditors: string[],
   warningText: string,
 }
 
 export default defineComponent({
   name: 'PermissionsModal',
+  components: {
+    UserSearch
+  },
   data(): PermissionsModalDataType {
     return {
       visible: true,
       allUsers: [],
       selectedViewers: [],
       selectedEditors: [],
-      userSelectHeight: 100,
       warningText: 'Warning: Updating the permissions of an audioEvent will \
       overwrite the permissions of all recordings associated with that \
       audioEvent.'
@@ -126,6 +102,9 @@ export default defineComponent({
     
     try {
       this.allUsers = await getAllUsers();
+      this.allUsers = this.allUsers.filter(user => {
+        return user._id !== this.$store.state.userID
+      });
       this.allUsers.sort((a, b) => {
         if (a.family_name < b.family_name) return -1;
         else if (a.family_name > b.family_name) return 1;
@@ -133,12 +112,8 @@ export default defineComponent({
         else if (a.given_name > b.given_name) return 1;
         else return 0
       })
-      this.selectedEditors = this.explicitPermissions.edit.map(userID => {
-        return this.allUsers.find(user => user._id === userID);
-      });
-      this.selectedViewers = this.explicitPermissions.view.map(userID => {
-        return this.allUsers.find(user => user._id === userID);
-      });
+      this.selectedEditors = [...this.explicitPermissions.edit];
+      this.selectedViewers = [...this.explicitPermissions.view];
     } catch (error) {
       console.log(error);
     }
@@ -160,28 +135,14 @@ export default defineComponent({
 
   methods: {
     async handleUpdate() {
-      const edit = this.selectedEditors
-        .filter(editor => editor !== undefined)
-        .map(editor => editor!._id) as string[];
-      const view = this.selectedViewers
-        .filter(viewer => viewer !== undefined)
-        .map(viewer => viewer!._id) as string[];
       const explicitPermissions = {
         publicView: this.visible,
-        edit,
-        view
+        edit: this.selectedEditors,
+        view: this.selectedViewers
       }
       const exp = explicitPermissions;
       await updateVisibility(this.artifactType, this.artifactID, exp);
       this.$emit('close');
-    },
-
-    addViewer() {
-      this.selectedViewers.push(undefined);
-    },
-
-    addEditor() {
-      this.selectedEditors.push(undefined);
     },
   },
 
@@ -222,8 +183,8 @@ export default defineComponent({
   background-color: lightgrey;
   padding: 20px;
   border-radius: 4px;
-  height: 250px;
-  width: 500px;
+  min-height: 280px;
+  width: 700px;
   display: flex;
   flex-direction: column;
   justify-content: top;
@@ -240,8 +201,9 @@ export default defineComponent({
 .modalRow.users {
   margin-top: 10px;
   align-items: top;
-  height: v-bind(userSelectHeight + 30 + 'px');
+  height: 130px;
   border: 1px solid black;
+  gap: 20px;
 }
 
 .modalRow.tall {
@@ -271,31 +233,10 @@ select.visibility {
 }
 
 .wide {
-  width: 250px;
-  height: v-bind(userSelectHeight + 30 + 'px');
-
+  width: 320px;
+  height: 130px;
 }
 
-.userSelectColumn {
-  display: flex;
-  flex-direction: column;
-  justify-content: left;
-  align-items: left;
-  height: v-bind(userSelectHeight + 'px');
-
-  width: 100%;;
-}
-
-.usersBox {
-  display: flex;
-  flex-direction: column;
-  justify-content: left;
-  align-items: left;
-  max-height: v-bind(userSelectHeight - 30 + 'px');
-  width: 200px;
-  margin-bottom: 5px;
-  overflow-y: scroll;
-}
 
 
 .labelBox {
@@ -308,19 +249,6 @@ select.visibility {
   /* width: 200px; */
 }
 
-.addButton {
-  height: 30px;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-}
-
-select {
-  margin-right: 5px;
-  width: 150px;
-}
 
 button.update {
   margin-top: 5px;

--- a/src/comps/files/UserSearch.vue
+++ b/src/comps/files/UserSearch.vue
@@ -145,7 +145,8 @@ export default defineComponent({
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  background-color: #202621;
+  background-color: #f5f5f5;
+  color: #333;
 }
 
 .result-text {
@@ -153,7 +154,7 @@ export default defineComponent({
 }
 
 .result-item:hover {
-  background-color: #f0f0f0;
+  background-color: #e0e0e0;
 }
 
 .no-results {


### PR DESCRIPTION
## Summary
- Replace dropdown-based user selection in PermissionsModal with modern UserSearch component
- Achieve UI consistency with NewPieceRegistrar for permission management
- Improve user experience with searchable, tag-based user selection interface

## Changes
- Integrated UserSearch component into PermissionsModal.vue
- Updated data structure from `(UserType | undefined)[]` to cleaner `string[]` arrays
- Removed clunky dropdown selects in favor of search-based selection
- Fixed contrast issues in UserSearch component (light background for better readability)
- Increased modal width (500px → 700px) to prevent email address overflow
- Cleaned up unused CSS styles related to old dropdown system
- Added filtering to exclude current user from selectable users

## Test plan
- [ ] Open a transcription and click to edit permissions
- [ ] Verify search functionality works for finding users
- [ ] Test adding users as editors
- [ ] Test adding users as viewers (when visibility is Private)
- [ ] Verify selected users appear as tags with remove buttons
- [ ] Confirm permissions update correctly when clicking Update
- [ ] Check that current user is not shown in search results
- [ ] Verify modal displays email addresses without overflow

🤖 Generated with [Claude Code](https://claude.ai/code)