### PR TITLE
Add academic paper links and Python package to landing page

### DIFF
--- a/public/papers/README.md
+++ b/public/papers/README.md
@@ -1,0 +1,10 @@
+# Papers Directory
+
+This directory contains academic papers and whitepapers related to IDTAP.
+
+## Files to place here:
+
+1. **ismir-paper.pdf** - The ISMIR conference paper
+2. **neh-whitepaper.pdf** - The NEH whitepaper
+
+Both files will be served statically and accessible via the landing page buttons.

--- a/public/papers/ismir-paper.pdf
+++ b/public/papers/ismir-paper.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a925e2095f0f6125d3a0e62402c247d4fa2b4e4133ce74e389060e88320ced03
+size 453656

--- a/public/papers/neh-whitepaper.pdf
+++ b/public/papers/neh-whitepaper.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e2c49c70559b3cfbfcc73ce6397a6db8e4b9d5d9badee194c90626b8b0cedc6
+size 2788325

--- a/src/comps/LandingPage.vue
+++ b/src/comps/LandingPage.vue
@@ -11,6 +11,21 @@
           </a>
         </div>
         <div class='enterButton' @click='goToChangelog'>Changelog</div>
+        <div class='linkButton'>
+          <a href='https://pypi.org/project/idtap/' target='_blank'>
+            Python Package
+          </a>
+        </div>
+        <div class='linkButton'>
+          <a href='/papers/ismir-paper.pdf' target='_blank'>
+            ISMIR Paper
+          </a>
+        </div>
+        <div class='linkButton'>
+          <a href='/papers/neh-whitepaper.pdf' target='_blank'>
+            NEH Whitepaper
+          </a>
+        </div>
       </div>
     </div>
       <div class='infoRowInner'>
@@ -239,7 +254,6 @@ export default {
 
 
 .buttonRow > div {
-  width: 100px;
   height: 40px;
   display: flex;
   align-items: center;
@@ -251,6 +265,8 @@ export default {
   transition: background-color 0.3s ease;
   transition: color 0.3s ease;
   margin-right: 10px;
+  padding: 0 12px;
+  width: fit-content;
 }
 
 .buttonRow > div:hover {


### PR DESCRIPTION
## Summary
- Add three new buttons to the landing page for external resources:
  - **Python Package** - links to PyPI (https://pypi.org/project/idtap/)
  - **ISMIR Paper** - links to academic paper PDF
  - **NEH Whitepaper** - links to whitepaper PDF

## Changes Made
- Added new buttons to the button row in LandingPage.vue
- Created `/public/papers/` directory for PDF storage
- Updated button styling to use `width: fit-content` for optimal text-based sizing
- All external links open in new tabs for better UX

## Files to Add
Place the following PDF files in `/public/papers/`:
- `ismir-paper.pdf` - The ISMIR conference paper  
- `neh-whitepaper.pdf` - The NEH whitepaper

🤖 Generated with [Claude Code](https://claude.ai/code)