### PR TITLE
feat: add timing display toggle for excerpt transcriptions

### DIFF
--- a/shared/enums.ts
+++ b/shared/enums.ts
@@ -63,6 +63,11 @@ enum ScaleSystem {
   MovableCCents = 'Movable C Pitch + Cents',
 }
 
+enum TimingDisplay {
+  ExcerptTime = 'Excerpt Time',
+  RealTime = 'Real Time',
+}
+
 enum SargamRepresentation {
   Sargam = 'Sargam',
   Solfege = 'Solfege',
@@ -114,6 +119,7 @@ export {
   ControlsMode,
   PlayheadAnimations,
   ScaleSystem,
+  TimingDisplay,
   SargamRepresentation,
   PhonemeRepresentation,
   LabelScheme,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -15,6 +15,7 @@ import {
   Instrument, 
   PlayheadAnimations, 
   ScaleSystem,
+  TimingDisplay,
   Segmentation,
   PitchInclusionMethod,
   PitchRepresentation,
@@ -927,6 +928,7 @@ type DisplaySettings = {
   highlightTrajs: boolean,
   uniqueId: string,
   scaleSystem?: ScaleSystem,
+  timingDisplay?: TimingDisplay,
   visibility?: {
     spectrogram: boolean,
     melograph: boolean,

--- a/src/comps/editor/EditorComponent.vue
+++ b/src/comps/editor/EditorComponent.vue
@@ -51,6 +51,7 @@
       :queryTime='queryTime'
       :editableCols='editableCols'
       :scaleSystem='scaleSystem'
+      :timingDisplay='timingDisplay'
       :audioPlayerRef='$refs.audioPlayer as APType'
       :showPhrases='showPhrases'
       @zoomInY='zoomInY'
@@ -227,6 +228,7 @@
   :zoomXFactor='zoomXFactor'
   :zoomYFactor='zoomYFactor'
   :scaleSystem='scaleSystem'
+  :timingDisplay='timingDisplay'
   :hasSitar='hasSitar'
   :hasVocal='vocal'
   :showSpectrogram='showSpectrogram'
@@ -273,6 +275,7 @@
   @scrollBackForPlayheadReturn='scrollBackForPlayhead'
   @update:zoomFactors='updateZoomFactors'
   @update:scaleSystem='scaleSystem = $event'
+  @update:timingDisplay='timingDisplay = $event'
   @update:showSpectrogram='showSpectrogram = $event'
   @update:showMelograph='melographVisible = $event'
   @update:showSargam='showSargam = $event'
@@ -411,6 +414,7 @@ import {
   ControlsMode, 
   PlayheadAnimations,
   ScaleSystem,
+  TimingDisplay,
   SargamRepresentation,
   PhonemeRepresentation
 } from '@shared/enums';
@@ -647,6 +651,7 @@ type EditorDataType = {
   editableCols: CollectionType[],
   showRemoveFromCollection: boolean,
   scaleSystem: ScaleSystem,
+  timingDisplay: TimingDisplay,
   excerptRange?: ExcerptRange,
   showPhrases: boolean,
 }
@@ -815,6 +820,7 @@ export default defineComponent({
       editableCols: [],
       showRemoveFromCollection: false,
       scaleSystem: ScaleSystem.Sargam,
+      timingDisplay: TimingDisplay.ExcerptTime,
       excerptRange: undefined,
       showPhrases: true,
     }

--- a/src/comps/editor/Renderer.vue
+++ b/src/comps/editor/Renderer.vue
@@ -37,6 +37,8 @@
           :instIdx='editingInstIdx'
           :showPhrases='showPhrases'
           :instTracks='instTracks'
+          :timingDisplay='timingDisplay'
+          :excerptRange='piece.excerptRange'
           @update:region='updateRegion'
           ref='xAxis'/>
       </div>
@@ -223,6 +225,7 @@ import {
   Instrument, 
   PlayheadAnimations, 
   ScaleSystem,
+  TimingDisplay,
   PhonemeRepresentation,
   SargamRepresentation,
 } from '@shared/enums';
@@ -425,6 +428,10 @@ export default defineComponent({
     },
     scaleSystem: {
       type: String as PropType<ScaleSystem>,
+      required: true
+    },
+    timingDisplay: {
+      type: String as PropType<TimingDisplay>,
       required: true
     },
     audioPlayerRef: {

--- a/src/comps/editor/audioPlayer/EditorAudioPlayer.vue
+++ b/src/comps/editor/audioPlayer/EditorAudioPlayer.vue
@@ -337,6 +337,7 @@
       :zoomXFactor='zoomXFactor'
       :zoomYFactor='zoomYFactor'
       :scaleSystem='scaleSystem'
+      :timingDisplay='timingDisplay'
       :hasSitar='hasSitar'
       :hasVocal='hasVocal'
       :hasRecording='hasRecording'
@@ -369,6 +370,7 @@
       @update:highlightTrajs='$emit("update:highlightTrajs", $event)'
       @update:zoomFactors='$emit("update:zoomFactors", $event)'
       @update:scaleSystem='$emit("update:scaleSystem", $event)'
+      @update:timingDisplay='$emit("update:timingDisplay", $event)'
       @update:showSpectrogram='$emit("update:showSpectrogram", $event)'
       @update:showMelograph='$emit("update:showMelograph", $event)'
       @update:showSargam='$emit("update:showSargam", $event)'
@@ -443,7 +445,8 @@ import {
   PlayheadAnimations,
   ControlsMode,
   Instrument,
-  ScaleSystem
+  ScaleSystem,
+  TimingDisplay
  } from '@shared/enums';
 import { AudioWorklet } from '@/audio-worklet';
 import { excelData, jsonData } from '@/js/serverCalls.ts';
@@ -1020,6 +1023,10 @@ export default defineComponent({
     },
     scaleSystem: {
       type: String as PropType<ScaleSystem>,
+      required: true
+    },
+    timingDisplay: {
+      type: String as PropType<TimingDisplay>,
       required: true
     },
     hasSitar: {

--- a/src/comps/editor/audioPlayer/SpectrogramControls.vue
+++ b/src/comps/editor/audioPlayer/SpectrogramControls.vue
@@ -283,6 +283,16 @@
           </select>
         </div>
       </div>
+      <div class='rowBox' v-if='excerptRange !== undefined'>
+        <label>Timing Display</label>
+        <div class='row'>
+          <select v-model='timingDisplayProxy'>
+            <option v-for='timing in possibleTimingDisplays' :value='timing'>
+              {{ timing }}
+            </option>
+          </select>
+        </div>
+      </div>
     </div>
     <div class='col'>
       <div class='titleBox'>
@@ -364,7 +374,7 @@ import {
   ExcerptRange,
   ProcessMessage
 } from '@shared/types';
-import { PlayheadAnimations, ScaleSystem } from '@shared/enums';
+import { PlayheadAnimations, ScaleSystem, TimingDisplay } from '@shared/enums';
 import SwatchSelect from '@/comps/SwatchSelect.vue';
 import {
   Pitch, 
@@ -492,6 +502,10 @@ export default defineComponent({
       type: String as PropType<ScaleSystem>,
       required: true
     },
+    timingDisplay: {
+      type: String as PropType<TimingDisplay>,
+      required: true
+    },
     hasSitar: {
       type: Boolean,
       required: true
@@ -571,6 +585,7 @@ export default defineComponent({
     'update:highlightTrajs',
     'update:zoomFactors',
     'update:scaleSystem',
+    'update:timingDisplay',
     'update:showSpectrogram',
     'update:showMelograph',
     'update:showSargam',
@@ -623,6 +638,7 @@ export default defineComponent({
       "highlightTrajs": true,
       "uniqueId": "ffa38001-f592-4778-a91e-c4ef5c99b081",
       "scaleSystem": ScaleSystem.Sargam,
+      "timingDisplay": TimingDisplay.ExcerptTime,
     } as DisplaySettings;
 
     const intensityPower = ref(1);
@@ -651,6 +667,7 @@ export default defineComponent({
     const savedSettings = ref<DisplaySettings[]>([]);
     const selectedSetting = ref<DisplaySettings>(defaultSetting);
     const possibleScaleSystems = Object.values(ScaleSystem);
+    const possibleTimingDisplays = Object.values(TimingDisplay);
 
     const playheadAnimations = Object.values(PlayheadAnimations);
     const store = useStore();
@@ -677,6 +694,14 @@ export default defineComponent({
       },
       set(val) {
         emit('update:scaleSystem', val);
+      }
+    })
+    const timingDisplayProxy = computed({
+      get() {
+        return props.timingDisplay;
+      },
+      set(val) {
+        emit('update:timingDisplay', val);
       }
     })
     const spectrogramToggleProxy = computed({
@@ -1087,6 +1112,7 @@ export default defineComponent({
         zoomXFactor: props.zoomXFactor,
         zoomYFactor: props.zoomYFactor,
         scaleSystem: scaleSystemProxy.value,
+        timingDisplay: timingDisplayProxy.value,
         visibility
       }
     };
@@ -1150,6 +1176,9 @@ export default defineComponent({
       }
       if (s.scaleSystem !== undefined) {
         scaleSystemProxy.value = s.scaleSystem;
+      }
+      if (s.timingDisplay !== undefined) {
+        timingDisplayProxy.value = s.timingDisplay;
       }
       if (s.visibility !== undefined) {
         spectrogramToggleProxy.value = s.visibility.spectrogram;
@@ -1267,6 +1296,8 @@ export default defineComponent({
       highlightTrajsProxy,
       possibleScaleSystems,
       scaleSystemProxy,
+      timingDisplayProxy,
+      possibleTimingDisplays,
       preventSpaceToggle,
       spectrogramToggleProxy,
       melographToggleProxy,

--- a/src/comps/editor/renderer/XAxis.vue
+++ b/src/comps/editor/renderer/XAxis.vue
@@ -18,7 +18,8 @@ import {
 import * as d3 from 'd3';
 import { getContrastingTextColor } from '@/ts/utils.ts';
 import { Piece } from '@model';
-import { InstrumentTrackType } from '@shared/types';
+import { InstrumentTrackType, ExcerptRange } from '@shared/types';
+import { TimingDisplay } from '@shared/enums';
 
 export default defineComponent({
   name: 'XAxis',
@@ -55,6 +56,14 @@ export default defineComponent({
       type: Array as PropType<InstrumentTrackType[]>,
       required: true
     },
+    timingDisplay: {
+      type: String as PropType<TimingDisplay>,
+      required: true
+    },
+    excerptRange: {
+      type: Object as PropType<ExcerptRange>,
+      required: false
+    },
   },
   setup(props, { emit }) {
     const xAxisContainer = ref<HTMLDivElement | null>(null);
@@ -83,6 +92,7 @@ export default defineComponent({
       }
     })
     watch(() => props.instIdx, () => resetAxis())
+    watch(() => props.timingDisplay, () => resetAxis())
 
     const leadingZeros = (int: number) => {
       if (int < 10) {
@@ -92,9 +102,14 @@ export default defineComponent({
       }
     }
     const structuredTime = (dur: number) => {
-      const hours = String(Math.floor(dur / 3600));
-      let minutes = Math.floor((dur % 3600) / 60);
-      const seconds = leadingZeros(dur % 60);
+      // Apply offset for real time display if in real time mode
+      const adjustedDur = props.timingDisplay === TimingDisplay.RealTime && props.excerptRange
+        ? dur + props.excerptRange.start
+        : dur;
+      
+      const hours = String(Math.floor(adjustedDur / 3600));
+      let minutes = Math.floor((adjustedDur % 3600) / 60);
+      const seconds = leadingZeros(adjustedDur % 60);
       if (Number(hours) > 0) {
         return `${hours}:${leadingZeros(minutes)}:${seconds}`
       } else {


### PR DESCRIPTION
## Summary
Adds a timing display toggle for excerpt transcriptions that allows users to switch between "excerpt time" (starting from 0:00) and "real time" (showing actual time from the original recording).

## Changes
- **New TimingDisplay enum** with ExcerptTime and RealTime options
- **UI Control**: Dropdown in SpectrogramControls (only visible for excerpts)
- **X-Axis Logic**: Modified to apply offset when in RealTime mode
- **Persistence**: Added to DisplaySettings type for save/load functionality
- **Default Behavior**: ExcerptTime for backward compatibility

## Test plan
- [ ] Open a transcription with an excerpt range
- [ ] Verify timing display dropdown appears in SpectrogramControls
- [ ] Test switching between "Excerpt Time" and "Real Time"
- [ ] Verify X-axis timing updates correctly in both modes
- [ ] Confirm setting persists when saving/loading display settings
- [ ] Verify dropdown is hidden for full-recording transcriptions

🤖 Generated with [Claude Code](https://claude.ai/code)