### PR TITLE
Fix meter refresh on zoom changes (Issue #814)

### DIFF
--- a/src/comps/editor/renderer/TranscriptionLayer.vue
+++ b/src/comps/editor/renderer/TranscriptionLayer.vue
@@ -4372,25 +4372,29 @@ export default defineComponent({
 
     const resetObserver = () => {
       observer.disconnect();
-      emptyDivs.value.forEach(div => {
-        observer.observe(div);
-        // Check if div is already intersecting and render meters immediately if so
-        const rect = div.getBoundingClientRect();
-        const containerRect = emptyOverlay.value?.getBoundingClientRect();
-        if (containerRect) {
-          const isIntersecting = rect.left < containerRect.right && 
-                                rect.right > containerRect.left &&
-                                rect.top < containerRect.bottom && 
-                                rect.bottom > containerRect.top;
-          if (isIntersecting) {
-            const idx = emptyDivIdxMap.get(div)!;
+      
+      // Create a temporary observer to immediately check for intersections
+      const tempObserver = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            const idx = emptyDivIdxMap.get(entry.target as HTMLDivElement)!;
             const dur = chunkDur.value;
             // Only render meters for already visible chunks
             props.piece.chunkedMeters(dur)[idx].forEach(m => {
               renderMeter(m);
-            })
+            });
           }
-        }
+        });
+        tempObserver.disconnect(); // Clean up temp observer
+      }, {
+        root: emptyOverlay.value,
+        rootMargin: '0px',
+        threshold: 0.0
+      });
+      
+      emptyDivs.value.forEach(div => {
+        observer.observe(div);
+        tempObserver.observe(div); // Check immediate intersection
       });
     };
 

--- a/src/comps/editor/renderer/TranscriptionLayer.vue
+++ b/src/comps/editor/renderer/TranscriptionLayer.vue
@@ -4374,7 +4374,7 @@ export default defineComponent({
       observer.disconnect();
       emptyDivs.value.forEach(div => {
         observer.observe(div);
-        // Check if div is already intersecting and render immediately if so
+        // Check if div is already intersecting and render meters immediately if so
         const rect = div.getBoundingClientRect();
         const containerRect = emptyOverlay.value?.getBoundingClientRect();
         if (containerRect) {
@@ -4385,37 +4385,10 @@ export default defineComponent({
           if (isIntersecting) {
             const idx = emptyDivIdxMap.get(div)!;
             const dur = chunkDur.value;
-            for (let inst = 0; inst < props.piece.instrumentation.length; inst++) {
-              props.piece.chunkedDisplaySargam(inst, dur)[idx].forEach(s => {
-                renderSargam(s);
-              });
-              const insts = [Instrument.Vocal_M, Instrument.Vocal_F];
-              if (insts.includes(props.piece.instrumentation[inst] as Instrument)) {
-                props.piece.chunkedDisplayVowels(inst, dur)[idx].forEach(v => {
-                  renderVowel(v);
-                })
-                props.piece.chunkedDisplayConsonants(inst, dur)[idx].forEach(c => {
-                  renderEndingConsonant(c);
-                })
-              } else if (props.piece.instrumentation[inst] === Instrument.Sitar) {
-                props.piece.chunkedDisplayChikaris(inst, dur)[idx].forEach(cd => {
-                  renderChikari(cd);
-                });
-                props.piece.chunkedDisplayBols(inst, dur)[idx].forEach(b => {
-                  renderBol(b);
-                })
-              }
-              props.piece.chunkedTrajs(inst, dur)[idx].forEach(traj => {
-                if (traj.id !== 12) renderTraj(traj);
-              });
-              props.piece.chunkedPhraseDivs(inst, dur)[idx].forEach(pd => {
-                renderPhraseDiv(pd);
-              });
-            }
+            // Only render meters for already visible chunks
             props.piece.chunkedMeters(dur)[idx].forEach(m => {
               renderMeter(m);
             })
-            observer.unobserve(div);
           }
         }
       });

--- a/src/comps/editor/renderer/TranscriptionLayer.vue
+++ b/src/comps/editor/renderer/TranscriptionLayer.vue
@@ -2387,7 +2387,6 @@ export default defineComponent({
       d3.selectAll('.sargamLinesG').remove();
       d3.selectAll('.chikariG').remove();
       d3.selectAll('.bolsG').remove();
-      d3.selectAll('.metricGrid').remove();
       d3.selectAll('.regionG').remove();
       d3.selectAll('.meterG').remove();
 
@@ -4375,6 +4374,50 @@ export default defineComponent({
       observer.disconnect();
       emptyDivs.value.forEach(div => {
         observer.observe(div);
+        // Check if div is already intersecting and render immediately if so
+        const rect = div.getBoundingClientRect();
+        const containerRect = emptyOverlay.value?.getBoundingClientRect();
+        if (containerRect) {
+          const isIntersecting = rect.left < containerRect.right && 
+                                rect.right > containerRect.left &&
+                                rect.top < containerRect.bottom && 
+                                rect.bottom > containerRect.top;
+          if (isIntersecting) {
+            const idx = emptyDivIdxMap.get(div)!;
+            const dur = chunkDur.value;
+            for (let inst = 0; inst < props.piece.instrumentation.length; inst++) {
+              props.piece.chunkedDisplaySargam(inst, dur)[idx].forEach(s => {
+                renderSargam(s);
+              });
+              const insts = [Instrument.Vocal_M, Instrument.Vocal_F];
+              if (insts.includes(props.piece.instrumentation[inst] as Instrument)) {
+                props.piece.chunkedDisplayVowels(inst, dur)[idx].forEach(v => {
+                  renderVowel(v);
+                })
+                props.piece.chunkedDisplayConsonants(inst, dur)[idx].forEach(c => {
+                  renderEndingConsonant(c);
+                })
+              } else if (props.piece.instrumentation[inst] === Instrument.Sitar) {
+                props.piece.chunkedDisplayChikaris(inst, dur)[idx].forEach(cd => {
+                  renderChikari(cd);
+                });
+                props.piece.chunkedDisplayBols(inst, dur)[idx].forEach(b => {
+                  renderBol(b);
+                })
+              }
+              props.piece.chunkedTrajs(inst, dur)[idx].forEach(traj => {
+                if (traj.id !== 12) renderTraj(traj);
+              });
+              props.piece.chunkedPhraseDivs(inst, dur)[idx].forEach(pd => {
+                renderPhraseDiv(pd);
+              });
+            }
+            props.piece.chunkedMeters(dur)[idx].forEach(m => {
+              renderMeter(m);
+            })
+            observer.unobserve(div);
+          }
+        }
       });
     };
 

--- a/src/comps/editor/renderer/TranscriptionLayer.vue
+++ b/src/comps/editor/renderer/TranscriptionLayer.vue
@@ -2387,6 +2387,7 @@ export default defineComponent({
       d3.selectAll('.sargamLinesG').remove();
       d3.selectAll('.chikariG').remove();
       d3.selectAll('.bolsG').remove();
+      d3.selectAll('.metricGrid').remove();
       d3.selectAll('.regionG').remove();
       d3.selectAll('.meterG').remove();
 

--- a/src/comps/editor/renderer/TranscriptionLayer.vue
+++ b/src/comps/editor/renderer/TranscriptionLayer.vue
@@ -4377,12 +4377,14 @@ export default defineComponent({
       const tempObserver = new IntersectionObserver((entries) => {
         entries.forEach(entry => {
           if (entry.isIntersecting) {
-            const idx = emptyDivIdxMap.get(entry.target as HTMLDivElement)!;
-            const dur = chunkDur.value;
-            // Only render meters for already visible chunks
-            props.piece.chunkedMeters(dur)[idx].forEach(m => {
-              renderMeter(m);
-            });
+            const idx = emptyDivIdxMap.get(entry.target as HTMLDivElement);
+            if (idx !== undefined) {
+              const dur = chunkDur.value;
+              // Only render meters for already visible chunks
+              props.piece.chunkedMeters(dur)[idx].forEach(m => {
+                renderMeter(m);
+              });
+            }
           }
         });
         tempObserver.disconnect(); // Clean up temp observer


### PR DESCRIPTION
## Summary
Fixes issue #814 where meters only refreshed when the IntersectionObserver detected changes at the start of the meter chunk, causing long meters to not appear after zoom changes until scrolling back to their beginning.

## Changes
- Modified `resetObserver()` function in TranscriptionLayer.vue
- Added temporary IntersectionObserver to immediately check for visible chunks after zoom/width changes
- Uses same observer configuration as main observer for consistent intersection detection
- Only renders meters for currently visible chunks, letting other elements use normal observer flow

## Test plan
- [x] Open transcription with long meters that span multiple chunks
- [x] Zoom in/out to change the view scale  
- [x] Verify meters appear immediately in visible areas without requiring scroll to beginning
- [x] Confirm other elements (trajectories, sargam) still work normally

🤖 Generated with [Claude Code](https://claude.ai/code)