### PR TITLE
Fix pitch snapping time threshold consistency

### DIFF
--- a/src/comps/editor/renderer/TranscriptionLayer.vue
+++ b/src/comps/editor/renderer/TranscriptionLayer.vue
@@ -3881,7 +3881,7 @@ export default defineComponent({
             const diff = Math.abs(logFreq - prevPitch.logFreq);
             const prevTime = phrase.startTime! + prevTraj.startTime! + prevTraj.durTot;
             const timeDiff = Math.abs(newTime - prevTime);
-            if (diff < 0.05 && timeDiff < 0.1) {
+            if (diff < 0.05 && timeDiff < minTrajDur) {
               logFreq = prevPitch.logFreq;
               newTime = prevTime;
             }
@@ -3901,7 +3901,7 @@ export default defineComponent({
             const diff = Math.abs(logFreq - nextPitch.logFreq);
             const nextTime = phrase.startTime! + nextTraj.startTime!;
             const timeDiff = Math.abs(nextTime - newTime);
-            if (diff < 0.05 && timeDiff < 0.1) {
+            if (diff < 0.05 && timeDiff < minTrajDur) {
               logFreq = nextPitch.logFreq;
               newTime = nextTime;
             }
@@ -4931,7 +4931,7 @@ export default defineComponent({
               const diff = Math.abs(newLogFreq - prevPitch.logFreq);
               const prevTime = phrase.startTime! + prevTraj.startTime! + prevTraj.durTot;
               const timeDiff = Math.abs(newTime - prevTime);
-              if (diff < 0.05 && timeDiff < 0.1) {
+              if (diff < 0.05 && timeDiff < minTrajDur) {
                 newTime = prevTime;
                 newLogFreq = prevPitch.logFreq;
                 const x = props.xScale(newTime);
@@ -4957,7 +4957,7 @@ export default defineComponent({
               const diff = Math.abs(newLogFreq - nextPitch.logFreq);
               const nextTime = phrase.startTime! + nextTraj.startTime!;
               const timeDiff = Math.abs(nextTime - newTime);
-              if (diff < 0.05 && timeDiff < 0.1) {
+              if (diff < 0.05 && timeDiff < minTrajDur) {
                 newTime = nextTime;
                 newLogFreq = nextPitch.logFreq;
                 const x = props.xScale(newTime);
@@ -5005,7 +5005,7 @@ export default defineComponent({
               const diff = Math.abs(newLogFreq - prevPitch.logFreq);
               const prevTime = phrase.startTime! + prevTraj.startTime! + prevTraj.durTot;
               const timeDiff = Math.abs(newTime - prevTime);
-              if (diff < 0.05 && timeDiff < 0.1) {
+              if (diff < 0.05 && timeDiff < minTrajDur) {
                 newLogFreq = prevPitch.logFreq;
                 newTime = prevTime;
               }
@@ -5025,7 +5025,7 @@ export default defineComponent({
               const diff = Math.abs(newLogFreq - nextPitch.logFreq);
               const nextTime = phrase.startTime! + nextTraj.startTime!;
               const timeDiff = Math.abs(nextTime - newTime);
-              if (diff < 0.05 && timeDiff < 0.1) {
+              if (diff < 0.05 && timeDiff < minTrajDur) {
                 newLogFreq = nextPitch.logFreq;
                 newTime = nextTime;
               }
@@ -5076,7 +5076,7 @@ export default defineComponent({
               const diff = Math.abs(newLogFreq - prevPitch.logFreq);
               const prevTime = phrase.startTime! + prevTraj.startTime! + prevTraj.durTot;
               const timeDiff = Math.abs(newTime - prevTime);
-              if (diff < 0.05 && timeDiff < 0.1) {
+              if (diff < 0.05 && timeDiff < minTrajDur) {
                 newLogFreq = prevPitch.logFreq;
                 newTime = prevTime;
               }
@@ -5096,7 +5096,7 @@ export default defineComponent({
               const diff = Math.abs(newLogFreq - nextPitch.logFreq);
               const nextTime = phrase.startTime! + nextTraj.startTime!;
               const timeDiff = Math.abs(nextTime - newTime);
-              if (diff < 0.05 && timeDiff < 0.1) {
+              if (diff < 0.05 && timeDiff < minTrajDur) {
                 newLogFreq = nextPitch.logFreq;
                 newTime = nextTime;
               }
@@ -5674,7 +5674,7 @@ export default defineComponent({
             const diff = Math.abs(lastPitch.logFreq - logFreq);
             const lastTime = prevTraj.startTime! + prevTraj.durTot;
             const timeDiff = Math.abs(time - lastTime);
-            if (diff < 0.05 && timeDiff < 0.1) {
+            if (diff < 0.05 && timeDiff < minTrajDur) {
               logFreq = lastPitch.logFreq;
             }
           }
@@ -5687,7 +5687,7 @@ export default defineComponent({
             const diff = Math.abs(firstPitch.logFreq - logFreq);
             const lastTime = traj.startTime! + traj.durTot;
             const timeDiff = Math.abs(lastTime - time);
-            if (diff < 0.05 && timeDiff < 0.1) {
+            if (diff < 0.05 && timeDiff < minTrajDur) {
               logFreq = firstPitch.logFreq;
             }
           }


### PR DESCRIPTION
## Summary
Follow-up to PR #815 - fixes inconsistent time thresholds for drag dot pitch snapping behavior.

## Changes
- Replace hardcoded 0.1s `timeDiff` thresholds with `minTrajDur` (0.01s)
- Makes pitch snapping behavior consistent with trajectory timing constraints  
- Reduces aggressive pitch snapping from 100ms to 10ms threshold
- Affects drag dot movement and trajectory connection logic across multiple functions

## Context
After fixing the minimum trajectory duration constraints, the pitch snapping logic was still using the old hardcoded 0.1 second threshold. This caused drag dots to still snap aggressively to nearby trajectory endpoints even with the reduced timing constraints.

## Test plan
- [x] Test drag dot movement with trajectories close in time
- [x] Verify pitch snapping is less aggressive (10ms vs 100ms threshold)
- [x] Confirm trajectory connections still work properly

🤖 Generated with [Claude Code](https://claude.ai/code)