### PR TITLE
fix: update Claude workflow to use official OAuth action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,4 +1,4 @@
-name: Claude PR Review
+name: Claude Code Review
 
 on:
   issue_comment:
@@ -6,103 +6,58 @@ on:
 
 jobs:
   claude-review:
+    # Only run on pull request comments that contain "@claude review"
     if: |
-      github.event.issue.pull_request && 
+      github.event.issue.pull_request &&
       contains(github.event.comment.body, '@claude review')
+    
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          
       - name: Get PR details
-        id: pr-details
         uses: actions/github-script@v7
+        id: pr-details
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
           script: |
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            
-            // Get the diff
-            const diff = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
               pull_number: context.issue.number,
-              mediaType: {
-                format: 'diff'
-              }
             });
-            
-            // Get changed files
-            const files = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            
-            return {
-              title: pr.data.title,
-              body: pr.data.body || '',
-              diff: diff.data,
-              files: files.data.map(f => ({
-                filename: f.filename,
-                additions: f.additions,
-                deletions: f.deletions,
-                changes: f.changes,
-                patch: f.patch || ''
-              }))
-            };
-      
-      - name: Review with Claude
-        id: claude-review
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          # Create a review request for Claude
-          cat > review_request.json << 'EOF'
-          {
-            "model": "claude-3-5-sonnet-20241022",
-            "max_tokens": 4096,
-            "messages": [
-              {
-                "role": "user",
-                "content": "You are reviewing a pull request for the IDTAP (Interactive Digital Transcription and Analysis Platform) project. This is a sophisticated web application for musical transcription and analysis, specifically focused on Indian classical music.\n\nPlease provide a thorough code review focusing on:\n1. Code quality and TypeScript/JavaScript best practices\n2. Potential bugs or issues\n3. Performance considerations\n4. Security concerns\n5. Consistency with the existing codebase\n6. Test coverage\n\nPR Title: ${{ fromJSON(steps.pr-details.outputs.result).title }}\n\nPR Description:\n${{ fromJSON(steps.pr-details.outputs.result).body }}\n\nChanged Files:\n${{ toJSON(fromJSON(steps.pr-details.outputs.result).files) }}\n\nPlease review the following diff and provide constructive feedback:\n\n```diff\n${{ fromJSON(steps.pr-details.outputs.result).diff }}\n```\n\nFormat your response as a helpful PR review comment with specific suggestions where applicable."
-              }
-            ]
-          }
-          EOF
-          
-          # Call Claude API
-          REVIEW=$(curl -s https://api.anthropic.com/v1/messages \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "anthropic-version: 2023-06-01" \
-            -d @review_request.json | jq -r '.content[0].text')
-          
-          # Save review to file for next step
-          echo "$REVIEW" > claude_review.md
-          
-      - name: Post review comment
-        uses: actions/github-script@v7
+            return pr.data.head.sha;
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const review = fs.readFileSync('claude_review.md', 'utf8');
+          ref: ${{ steps.pr-details.outputs.result }}
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
+          # model: "claude-opus-4-1-20250805"
+
+          # Direct prompt for manual review (triggered by @claude review comment)
+          direct_prompt: |
+            Please review this pull request for the IDTAP (Interactive Digital Transcription and Analysis Platform) project and provide feedback on:
+            - Code quality and TypeScript/JavaScript best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+            - Consistency with the existing codebase
             
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `## 🤖 Claude Review\n\n${review}\n\n---\n*This review was automatically generated by Claude AI in response to the \`@claude review\` command.*`
-            });
+            Be constructive and helpful in your feedback.
+
+          # Use sticky comments to update the same comment on subsequent reviews
+          use_sticky_comment: true


### PR DESCRIPTION
Fixes the Claude review workflow to use the proper GitHub App integration method.

## Changes:
- **Replace manual API calls** with 
- **Use OAuth token** () instead of API key
- **Match python-api setup** for consistency across repositories
- **Enable sticky comments** for better UX
- **Proper error handling** built into the official action

## Why this fix is needed:
The current workflow uses manual API calls with , but the repository is set up with GitHub App integration using OAuth tokens. This mismatch caused the 'null' response issue.

## Testing:
Once merged,  comments should work properly with the existing GitHub App integration.