### PR TITLE
fix: replace Claude workflow with working version from python-api

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -49,15 +49,15 @@ jobs:
 
           # Direct prompt for manual review (triggered by @claude review comment)
           direct_prompt: |
-            Please review this pull request for the IDTAP (Interactive Digital Transcription and Analysis Platform) project and provide feedback on:
-            - Code quality and TypeScript/JavaScript best practices
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
             - Security concerns
             - Test coverage
-            - Consistency with the existing codebase
             
             Be constructive and helpful in your feedback.
 
           # Use sticky comments to update the same comment on subsequent reviews
           use_sticky_comment: true
+


### PR DESCRIPTION
Replaces the current broken Claude review workflow with the exact working version from the python-api repository.

## Problem:
Current workflow fails with: `Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required`

## Solution:
- Copy exact `claude-code-review.yml` from python-api repository
- Uses `anthropics/claude-code-action@beta` with OAuth integration
- Matches the working setup from sister repository

## Next Step:
Add `CLAUDE_CODE_OAUTH_TOKEN` secret to repository settings to enable `@claude review` functionality.