### PR TITLE
fix: sync section categorization arrays when toggling phrase div type

### DIFF
--- a/src/comps/editor/TrajSelectPanel.vue
+++ b/src/comps/editor/TrajSelectPanel.vue
@@ -741,9 +741,48 @@ export default defineComponent({
     updatePhraseDivType() {
       const phrase = this.piece!.phraseFromUId(this.selectedPhraseDivUid!);
       const track = this.piece!.trackFromPhraseUId(this.selectedPhraseDivUid!);
+      const wasSection = phrase.isSectionStart;
+      const isNowSection = (this.phraseDivType === 'section');
 
-      // Simply toggle the phrase property - no manual index management needed
-      phrase.isSectionStart = (this.phraseDivType === 'section');
+      // Update the phrase property
+      phrase.isSectionStart = isNowSection;
+
+      // Sync section categorization arrays
+      const ss = this.piece!.sectionStartsGrid[track];
+      const pIdx = phrase.pieceIdx!;
+      const sectionIdx = ss.indexOf(pIdx);
+
+      if (isNowSection && !wasSection) {
+        // Changed from phrase to section - add section categorization
+        if (sectionIdx !== -1) {
+          // Insert empty categorization at the correct position
+          this.piece!.sectionCatGrid[track].splice(sectionIdx, 0, {
+            "Pre-Chiz Alap": { "Pre-Chiz Alap": false },
+            "Alap": { "Alap": false, "Jor": false, "Alap-Jhala": false },
+            "Composition Type": {
+              "Dhrupad": false, "Bandish": false, "Thumri": false, "Ghazal": false,
+              "Qawwali": false, "Dhun": false, "Tappa": false, "Bhajan": false,
+              "Kirtan": false, "Kriti": false, "Masitkhani Gat": false,
+              "Razakhani Gat": false, "Ferozkhani Gat": false
+            },
+            "Comp.-section/Tempo": {
+              "Ati Vilambit": false, "Vilambit": false, "Madhya": false,
+              "Drut": false, "Ati Drut": false, "Jhala": false
+            },
+            "Tala": { "Ektal": false, "Tintal": false, "Rupak": false },
+            "Improvisation": { "Improvisation": false },
+            "Other": { "Other": false },
+            "Top Level": "None"
+          });
+          this.piece!.adHocSectionCatGrid[track].splice(sectionIdx, 0, []);
+        }
+      } else if (!isNowSection && wasSection) {
+        // Changed from section to phrase - remove section categorization
+        if (sectionIdx !== -1) {
+          this.piece!.sectionCatGrid[track].splice(sectionIdx, 1);
+          this.piece!.adHocSectionCatGrid[track].splice(sectionIdx, 1);
+        }
+      }
 
       const pdObj: PhraseDivDisplayType = this.piece.allPhraseDivs(track)
           .find(pd => pd.uId === this.selectedPhraseDivUid)!;


### PR DESCRIPTION
## Summary
- Fixes bug where converting section divisions to phrase divisions didn't persist after save/reload
- `updatePhraseDivType()` now properly syncs `sectionCatGrid` and `adHocSectionCatGrid` arrays when toggling phrase div types

## Root Cause
When toggling `phrase.isSectionStart`, the function only updated the boolean flag but didn't sync the section categorization arrays. Since `sectionStartsGrid` is a computed property derived from the `isSectionStart` flags, the array indices changed but the categorization data became misaligned.

## Changes
1. Track state before/after toggle (`wasSection` → `isNowSection`)
2. When changing phrase → section: insert empty categorization objects at correct index
3. When changing section → phrase: remove categorization entries at correct index

## Test Plan
- [ ] Convert section division to phrase division
- [ ] Save transcription
- [ ] Reload page
- [ ] Verify change persisted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)