### PR TITLE
fix: remove legacy sectionStartsGrid from database on save

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -282,7 +282,13 @@ const runServer = async () => {
 	  updateObj['dateModified'] = new Date();
 	  updateObj['dateCreated'] = new Date(updateObj['dateCreated'])
 	  const query = { '_id': new ObjectId(req.body._id) };
-	  const update = { '$set': updateObj };
+	  const update = {
+		'$set': updateObj,
+		'$unset': {
+		  'sectionStartsGrid': '',  // Remove legacy field - now using phrase.isSectionStart
+		  'sectionStarts': ''        // Remove even older legacy field
+		}
+	  };
 	  try {
 		const result = await transcriptions.updateOne(query, update);
 		res.send(JSON.stringify({ ...result, dateModified: updateObj['dateModified'] }))

--- a/src/comps/editor/TrajSelectPanel.vue
+++ b/src/comps/editor/TrajSelectPanel.vue
@@ -745,41 +745,27 @@ export default defineComponent({
       const isNowSection = (this.phraseDivType === 'section');
       const pIdx = phrase.pieceIdx!;
 
-      console.log('=== updatePhraseDivType ===');
-      console.log('Phrase index:', pIdx);
-      console.log('Was section:', wasSection, '→ Is now section:', isNowSection);
-      console.log('BEFORE - sectionCatGrid length:', this.piece!.sectionCatGrid[track].length);
-      console.log('BEFORE - sectionCatGrid:', JSON.parse(JSON.stringify(this.piece!.sectionCatGrid[track])));
-      console.log('BEFORE - adHocSectionCatGrid length:', this.piece!.adHocSectionCatGrid[track].length);
-      console.log('BEFORE - adHocSectionCatGrid:', JSON.parse(JSON.stringify(this.piece!.adHocSectionCatGrid[track])));
-      console.log('BEFORE - sectionStartsGrid:', this.piece!.sectionStartsGrid[track]);
-
       // Safety check: ensure arrays are in sync
       const numSections = this.piece!.sectionStartsGrid[track].length;
       if (this.piece!.adHocSectionCatGrid[track].length !== numSections) {
-        console.warn(`⚠️ Array mismatch detected! adHocSectionCatGrid has ${this.piece!.adHocSectionCatGrid[track].length} entries but there are ${numSections} sections. Fixing...`);
         // Pad with empty arrays
         while (this.piece!.adHocSectionCatGrid[track].length < numSections) {
           this.piece!.adHocSectionCatGrid[track].push([]);
         }
         // Trim if too long
         this.piece!.adHocSectionCatGrid[track].splice(numSections);
-        console.log('Fixed adHocSectionCatGrid length:', this.piece!.adHocSectionCatGrid[track].length);
       }
 
       // Get section index BEFORE changing the flag (for section→phrase removal)
       const oldSectionIdx = wasSection ? this.piece!.sectionStartsGrid[track].indexOf(pIdx) : -1;
-      console.log('Old section index:', oldSectionIdx);
 
       // Update the phrase property
       phrase.isSectionStart = isNowSection;
-      console.log('Set phrase.isSectionStart =', isNowSection);
 
       if (isNowSection && !wasSection) {
         // Changed from phrase to section - add section categorization
         // Get NEW section index after flag change
         const newSectionIdx = this.piece!.sectionStartsGrid[track].indexOf(pIdx);
-        console.log('New section index:', newSectionIdx);
         if (newSectionIdx !== -1) {
           // Insert empty categorization at the correct position
           this.piece!.sectionCatGrid[track].splice(newSectionIdx, 0, {
@@ -801,24 +787,14 @@ export default defineComponent({
             "Top Level": "None"
           });
           this.piece!.adHocSectionCatGrid[track].splice(newSectionIdx, 0, []);
-          console.log('Added categorization at index', newSectionIdx);
         }
       } else if (!isNowSection && wasSection) {
         // Changed from section to phrase - remove section categorization using OLD index
-        console.log('Removing categorization at OLD index:', oldSectionIdx);
         if (oldSectionIdx !== -1) {
           this.piece!.sectionCatGrid[track].splice(oldSectionIdx, 1);
           this.piece!.adHocSectionCatGrid[track].splice(oldSectionIdx, 1);
-          console.log('Removed categorization');
         }
       }
-
-      console.log('AFTER - sectionCatGrid length:', this.piece!.sectionCatGrid[track].length);
-      console.log('AFTER - sectionCatGrid:', JSON.parse(JSON.stringify(this.piece!.sectionCatGrid[track])));
-      console.log('AFTER - adHocSectionCatGrid length:', this.piece!.adHocSectionCatGrid[track].length);
-      console.log('AFTER - adHocSectionCatGrid:', JSON.parse(JSON.stringify(this.piece!.adHocSectionCatGrid[track])));
-      console.log('AFTER - sectionStartsGrid:', this.piece!.sectionStartsGrid[track]);
-      console.log('AFTER - phrase.isSectionStart:', phrase.isSectionStart);
 
       const pdObj: PhraseDivDisplayType = this.piece.allPhraseDivs(track)
           .find(pd => pd.uId === this.selectedPhraseDivUid)!;

--- a/src/comps/editor/TrajSelectPanel.vue
+++ b/src/comps/editor/TrajSelectPanel.vue
@@ -744,19 +744,20 @@ export default defineComponent({
       const wasSection = phrase.isSectionStart;
       const isNowSection = (this.phraseDivType === 'section');
 
+      // Get section index BEFORE changing the flag (for section→phrase removal)
+      const pIdx = phrase.pieceIdx!;
+      const oldSectionIdx = wasSection ? this.piece!.sectionStartsGrid[track].indexOf(pIdx) : -1;
+
       // Update the phrase property
       phrase.isSectionStart = isNowSection;
 
-      // Sync section categorization arrays
-      const ss = this.piece!.sectionStartsGrid[track];
-      const pIdx = phrase.pieceIdx!;
-      const sectionIdx = ss.indexOf(pIdx);
-
       if (isNowSection && !wasSection) {
         // Changed from phrase to section - add section categorization
-        if (sectionIdx !== -1) {
+        // Get NEW section index after flag change
+        const newSectionIdx = this.piece!.sectionStartsGrid[track].indexOf(pIdx);
+        if (newSectionIdx !== -1) {
           // Insert empty categorization at the correct position
-          this.piece!.sectionCatGrid[track].splice(sectionIdx, 0, {
+          this.piece!.sectionCatGrid[track].splice(newSectionIdx, 0, {
             "Pre-Chiz Alap": { "Pre-Chiz Alap": false },
             "Alap": { "Alap": false, "Jor": false, "Alap-Jhala": false },
             "Composition Type": {
@@ -774,13 +775,13 @@ export default defineComponent({
             "Other": { "Other": false },
             "Top Level": "None"
           });
-          this.piece!.adHocSectionCatGrid[track].splice(sectionIdx, 0, []);
+          this.piece!.adHocSectionCatGrid[track].splice(newSectionIdx, 0, []);
         }
       } else if (!isNowSection && wasSection) {
-        // Changed from section to phrase - remove section categorization
-        if (sectionIdx !== -1) {
-          this.piece!.sectionCatGrid[track].splice(sectionIdx, 1);
-          this.piece!.adHocSectionCatGrid[track].splice(sectionIdx, 1);
+        // Changed from section to phrase - remove section categorization using OLD index
+        if (oldSectionIdx !== -1) {
+          this.piece!.sectionCatGrid[track].splice(oldSectionIdx, 1);
+          this.piece!.adHocSectionCatGrid[track].splice(oldSectionIdx, 1);
         }
       }
 

--- a/src/comps/editor/TrajSelectPanel.vue
+++ b/src/comps/editor/TrajSelectPanel.vue
@@ -743,18 +743,43 @@ export default defineComponent({
       const track = this.piece!.trackFromPhraseUId(this.selectedPhraseDivUid!);
       const wasSection = phrase.isSectionStart;
       const isNowSection = (this.phraseDivType === 'section');
+      const pIdx = phrase.pieceIdx!;
+
+      console.log('=== updatePhraseDivType ===');
+      console.log('Phrase index:', pIdx);
+      console.log('Was section:', wasSection, '→ Is now section:', isNowSection);
+      console.log('BEFORE - sectionCatGrid length:', this.piece!.sectionCatGrid[track].length);
+      console.log('BEFORE - sectionCatGrid:', JSON.parse(JSON.stringify(this.piece!.sectionCatGrid[track])));
+      console.log('BEFORE - adHocSectionCatGrid length:', this.piece!.adHocSectionCatGrid[track].length);
+      console.log('BEFORE - adHocSectionCatGrid:', JSON.parse(JSON.stringify(this.piece!.adHocSectionCatGrid[track])));
+      console.log('BEFORE - sectionStartsGrid:', this.piece!.sectionStartsGrid[track]);
+
+      // Safety check: ensure arrays are in sync
+      const numSections = this.piece!.sectionStartsGrid[track].length;
+      if (this.piece!.adHocSectionCatGrid[track].length !== numSections) {
+        console.warn(`⚠️ Array mismatch detected! adHocSectionCatGrid has ${this.piece!.adHocSectionCatGrid[track].length} entries but there are ${numSections} sections. Fixing...`);
+        // Pad with empty arrays
+        while (this.piece!.adHocSectionCatGrid[track].length < numSections) {
+          this.piece!.adHocSectionCatGrid[track].push([]);
+        }
+        // Trim if too long
+        this.piece!.adHocSectionCatGrid[track].splice(numSections);
+        console.log('Fixed adHocSectionCatGrid length:', this.piece!.adHocSectionCatGrid[track].length);
+      }
 
       // Get section index BEFORE changing the flag (for section→phrase removal)
-      const pIdx = phrase.pieceIdx!;
       const oldSectionIdx = wasSection ? this.piece!.sectionStartsGrid[track].indexOf(pIdx) : -1;
+      console.log('Old section index:', oldSectionIdx);
 
       // Update the phrase property
       phrase.isSectionStart = isNowSection;
+      console.log('Set phrase.isSectionStart =', isNowSection);
 
       if (isNowSection && !wasSection) {
         // Changed from phrase to section - add section categorization
         // Get NEW section index after flag change
         const newSectionIdx = this.piece!.sectionStartsGrid[track].indexOf(pIdx);
+        console.log('New section index:', newSectionIdx);
         if (newSectionIdx !== -1) {
           // Insert empty categorization at the correct position
           this.piece!.sectionCatGrid[track].splice(newSectionIdx, 0, {
@@ -776,14 +801,24 @@ export default defineComponent({
             "Top Level": "None"
           });
           this.piece!.adHocSectionCatGrid[track].splice(newSectionIdx, 0, []);
+          console.log('Added categorization at index', newSectionIdx);
         }
       } else if (!isNowSection && wasSection) {
         // Changed from section to phrase - remove section categorization using OLD index
+        console.log('Removing categorization at OLD index:', oldSectionIdx);
         if (oldSectionIdx !== -1) {
           this.piece!.sectionCatGrid[track].splice(oldSectionIdx, 1);
           this.piece!.adHocSectionCatGrid[track].splice(oldSectionIdx, 1);
+          console.log('Removed categorization');
         }
       }
+
+      console.log('AFTER - sectionCatGrid length:', this.piece!.sectionCatGrid[track].length);
+      console.log('AFTER - sectionCatGrid:', JSON.parse(JSON.stringify(this.piece!.sectionCatGrid[track])));
+      console.log('AFTER - adHocSectionCatGrid length:', this.piece!.adHocSectionCatGrid[track].length);
+      console.log('AFTER - adHocSectionCatGrid:', JSON.parse(JSON.stringify(this.piece!.adHocSectionCatGrid[track])));
+      console.log('AFTER - sectionStartsGrid:', this.piece!.sectionStartsGrid[track]);
+      console.log('AFTER - phrase.isSectionStart:', phrase.isSectionStart);
 
       const pdObj: PhraseDivDisplayType = this.piece.allPhraseDivs(track)
           .find(pd => pd.uId === this.selectedPhraseDivUid)!;


### PR DESCRIPTION
## Summary
Fixes section→phrase toggles reverting on reload by removing legacy database fields.

## Root Cause
The old `sectionStartsGrid` field persisted in MongoDB even after we stopped saving it (using `$set` only updates provided fields). On reload, migration code would see both the new `phrase.isSectionStart` flags AND the old array, causing conflicts.

## Changes

### Server (`server.ts`)
- Add `$unset` to `/updateTranscription` endpoint to remove legacy fields:
  - `sectionStartsGrid` (newer legacy format)
  - `sectionStarts` (older legacy format)

### Client (`TrajSelectPanel.vue`)
- Fix timing: get section index BEFORE changing `phrase.isSectionStart` flag
  - For section→phrase: need old index to remove categorization
  - For phrase→section: need new index after flag change
- Add safety check: sync `adHocSectionCatGrid` length with `sectionCatGrid`
  - Fixes historical data corruption where arrays had mismatched lengths

## Test Plan
- [x] Toggle section division to phrase division
- [x] Save transcription
- [x] Reload page
- [x] Verify change persists (section is now phrase)

## Related
- Builds on PR #849 which added the categorization array syncing
- This PR adds the critical database cleanup to make changes persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)